### PR TITLE
强制用户安装并使用特定字体

### DIFF
--- a/.obsidian/appearance.json
+++ b/.obsidian/appearance.json
@@ -46,7 +46,8 @@
     "[Discord]书库小封面",
     "[PKMer]Timeline-Callouts",
     "[Forum]图片题注",
-    "Blue Topaz Legacy特制版"
+    "Blue Topaz Legacy特制版",
+    "字体大全-1999"
   ],
   "showRibbon": true
 }


### PR DESCRIPTION
本人诚恳地建议您强制用户安装并使用这一字体，原因：

> 1. 空间充足。既然空间已经不是重点考虑内容，那么这几Mb的字体也已经可以忽略不计。
> 2. 最佳实践演示。很多用户需要参考css-classes把字体玩出花来的效果，但是由于一定的技术难度一个最佳实践非常有建设意义。
> 3. 与游戏wiki的调性相符。游戏用什么字体，wiki就用什么字体，这是统一风格，很有沉浸感。
> 4. 这一仓库不以盈利为目的，统一的字体有利于观感，用户自行选择字体非常的繁琐、低效。

作为一个游戏配套的wiki，用户如果要开箱即用，看到下载之后还叫用户自己手动安装字体，用户会怎么想？所以，非常建议您强制用户安装并使用我制作的特定字体。